### PR TITLE
Removing deprecated sync request.open parameter.

### DIFF
--- a/src/Ajax.js
+++ b/src/Ajax.js
@@ -114,11 +114,10 @@ class Ajax {
 	 * @param {MultiMap=} opt_headers
 	 * @param {MultiMap=} opt_params
 	 * @param {number=} opt_timeout
-	 * @param {boolean=} opt_sync
 	 * @return {Promise} Deferred ajax request.
 	 * @protected
 	 */
-	static request(url, method, body, opt_headers, opt_params, opt_timeout, opt_sync) {
+	static request(url, method, body, opt_headers, opt_params, opt_timeout) {
 		var request = new XMLHttpRequest();
 
 		var promise = new Promise(function(resolve, reject) {
@@ -145,7 +144,7 @@ class Ajax {
 			url = Ajax.addParametersToUrlQueryString(url, opt_params);
 		}
 
-		request.open(method, url, !opt_sync);
+		request.open(method, url);
 
 		if (opt_headers) {
 			opt_headers.names().forEach(function(name) {


### PR DESCRIPTION
This parameter is considered deprecated by the current browsers.