### PR TITLE
Feature/cors

### DIFF
--- a/src/Ajax.js
+++ b/src/Ajax.js
@@ -63,7 +63,11 @@ class Ajax {
 				resolve(request);
 			};
 			request.onerror = function() {
-				var error = new Error('Request error');
+				var message = 'Request error';
+				if (4 === request.readyState && !request.responseURL) {
+					message = 'CORS error';
+				} 
+				var error = new Error(message);
 				error.request = request;
 				reject(error);
 			};

--- a/test/Ajax.js
+++ b/test/Ajax.js
@@ -195,6 +195,16 @@ describe('Ajax', function() {
 			this.requests[0].error();
 		});
 
+		it('should fail when attempting to fetch resource from cross domain', function(done) {			
+			Ajax.request('http://www.google.com')
+				.catch(function(reason) {
+					assert.ok(reason instanceof Error);
+					assert.strictEqual('CORS error', reason.message);
+					done();
+				});
+			this.requests[0].error();
+		});
+
 	});
 
 });

--- a/test/Ajax.js
+++ b/test/Ajax.js
@@ -38,6 +38,9 @@ describe('Ajax', function() {
 		});
 
 		afterEach(function() {
+			if (!this.xhr.restore) { 
+				return;
+			}
 			this.xhr.restore();
 		});
 
@@ -196,13 +199,13 @@ describe('Ajax', function() {
 		});
 
 		it('should fail when attempting to fetch resource from cross domain', function(done) {			
+			this.xhr.restore();
 			Ajax.request('http://www.google.com')
 				.catch(function(reason) {
 					assert.ok(reason instanceof Error);
 					assert.strictEqual('CORS error', reason.message);
 					done();
 				});
-			this.requests[0].error();
 		});
 
 	});


### PR DESCRIPTION
### Intent
To add functionality that tests the XHR instance when a network error occurs and gives an educated guess whether the XHR request was terminated by CORS issue.

### Solution
Provided ```responseURL``` remains empty, but ```readyState``` is ```4``` we assume is is blocked request due to cross browser origin issue.

### Tests
-  New unit test to cover this scenario automatically
- Tested manually against Safari, Chrome, FF, Edge

#### Notes
While reproducing the mentioned scenario in IE11, the request wasn't blocked and the 302 was appropriately processed. Nevertheless the content wasn't flipped as expected. 