### PR TITLE
enhance detection of blocked requests

### DIFF
--- a/src/Ajax.js
+++ b/src/Ajax.js
@@ -53,6 +53,7 @@ class Ajax {
 		method = method || 'GET';
 
 		var request = new XMLHttpRequest();
+		var previousReadyState = 0;
 
 		var promise = new Promise(function(resolve, reject) {
 			request.onload = function() {
@@ -62,8 +63,18 @@ class Ajax {
 				}
 				resolve(request);
 			};
+			request.onreadystatechange = function() {
+				if (previousReadyState && previousReadyState < 3 && 4 === request.readyState) {
+					request.terminatedPrematurely = true;
+				}
+				previousReadyState = request.readyState;
+			};
 			request.onerror = function() {
-				var error = new Error('Request error');
+				var message = 'Request error';
+				if (request.terminatedPrematurely) {
+					message = 'Request terminated prematurely';
+				} 
+				var error = new Error(message);
 				error.request = request;
 				reject(error);
 			};


### PR DESCRIPTION
### Intent
To provide a more solid functionality to capture unexpected terminations of the XHR communication such as CORS violation.

### Solution
- We test the XHR object against whether its ```readyState``` is updated as per the defined steps
- If we detect that the ```readyState``` skips any of the steps and gets settled to ```4``` we mark the XHR object as prematurely terminated (```xhr.prematurelyTerminated```). 
- The assumption is that if ```xhr.prematurelyTerminated``` is truthy and ```onerror``` is invoked, it will be a result of CORS violation.